### PR TITLE
Switch authentication to use offline token flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Build artifacts
 *__pycache__/
 build/
+*.pyc
 
 # Vim temporary files
 *~

--- a/README.md
+++ b/README.md
@@ -110,14 +110,15 @@ optional arguments:
  -h, --help            show this help message and exit
 
 authentication:
-  -u USERNAME, --username USERNAME
-                        Red Hat customer portal username
-  -p PASSWORD, --password PASSWORD
-                        Red Hat customer portal password
-  -c CLIENT_ID, --client_id CLIENT_ID
-                        Red Hat customer portal API Key Client ID
-  -s CLIENT_SECRET, --client_secret CLIENT_SECRET
-                        Red Hat customer portal API Key Client Secret
+-c CLIENT_ID, --client_id CLIENT_ID
+                      Red Hat Customer Portal OIDC client (default: rhsm-
+                      api)
+-i IDP_TOKEN_URL, --idp_token_url IDP_TOKEN_URL
+                      Red Hat Customer Portal SSO Token URL (default:
+                      https://sso.redhat.com/auth/realms/redhat-
+                      external/protocol/openid-connect/token)
+-t TOKEN, --token TOKEN
+                      Red Hat Customer Portal offline token
 ```
 
 ## Examples
@@ -125,7 +126,26 @@ authentication:
 * Generate CSV listing all systems
 
 ```
-$ ./rhsm-api-client.py -u 'MyRHNUsername' -p 'MyRHNPassword' -c 'MyClientID' -s 'MyClientSecret' systems -o /path/to/systems.csv -l 100
+$ ./rhsm-api-client.py -t 'MyOfflineToken' systems -o /path/to/systems.csv -l 100
+```
+
+## Offline Token Storage
+
+Your offline token is a form of credential and should be treated securely. To help prevent
+your token from being exposed in your shell history or via copy/paste, you can store your token
+as an environment variable in your shell profile.
+
+For example, with Bash you can add it to your `~/.bashrc` file and add the following line
+with your token obtained from the Customer Portal:
+
+```bash
+# RHSM API Token
+export RHSM_API_TOKEN=SOME_LONG_TOKEN_HERE
+```
+
+Then when calling your scripts, the token can be recalled via the variable:
+```
+$ ./rhsm-api-client.py -t $RHSM_API_TOKEN systems -o /path/to/systems.csv -l 100
 ```
 
 ## Authors

--- a/rhsm/client.py
+++ b/rhsm/client.py
@@ -52,9 +52,9 @@ class RHSMClient(object):
         else:
             csv_file.write_header(csv_header)
 
-        authorization = RHSMAuthorizationCode(self._args.username, self._args.password,
-                                              self._args.client_id, self._args.client_secret)
-        authorization.fetch_token()
+        authorization = RHSMAuthorizationCode(self._args.idp_token_url, self._args.client_id,
+                                              self._args.token)
+        authorization.refresh_token()
         api_service = RHSMApi(authorization)
 
         limit = int(self._args.limit)
@@ -130,14 +130,14 @@ def add_packages_command_options(subparsers):
 def _get_parser():
     parser = argparse.ArgumentParser(description="RHSM API implementation")
     group = parser.add_argument_group('authentication')
-    group.add_argument("-u", "--username", help="Red Hat customer portal username", required=True,
-                       action="store")
-    group.add_argument("-p", "--password", help="Red Hat customer portal password", required=True,
-                       action="store")
-    group.add_argument("-c", "--client_id", help="Red Hat customer portal API Key Client ID",
-                       required=True, action="store")
-    group.add_argument("-s", "--client_secret", help=("Red Hat customer portal API Key Client "
-                       "Secret"), required=True, action="store")
+    group.add_argument('-c', '--client_id', help=('Red Hat Customer Portal OIDC client '
+                       "(default: %(default)s)"), action='store', default='rhsm-api')
+    group.add_argument('-i', '--idp_token_url', help=('Red Hat Customer Portal SSO Token URL '
+                       "(default: %(default)s)"), action='store',
+                       default=('https://sso.redhat.com/auth/realms/redhat-external'
+                                '/protocol/openid-connect/token'))
+    group.add_argument('-t', '--token', help='Red Hat Customer Portal offline token',
+                       required=True, action='store')
 
     subparsers = parser.add_subparsers(help=('Program mode: systems, allocations, subscriptions, '
                                        'errata, packages)'), dest='mode')

--- a/rhsm/service.py
+++ b/rhsm/service.py
@@ -10,31 +10,24 @@
 import requests
 import time
 import sys
-from oauthlib.oauth2 import TokenExpiredError, LegacyApplicationClient
+from oauthlib.oauth2 import TokenExpiredError, Client
 from requests_oauthlib import OAuth2Session
 
 
 class RHSMAuthorizationCode(object):
-    TOKEN_URL = 'https://sso.redhat.com/auth/realms/3scale/protocol/openid-connect/token'
+    TOKEN_PATH = ''
 
-    def __init__(self, username, password, client_id, client_secret, token=None):
-        self.username = username
-        self.password = password
+    def __init__(self, token_url, client_id, offline_token, token=None):
+        self.token_url = token_url
         self.client_id = client_id
-        self.client_secret = client_secret
+        self.offline_token = offline_token
         self.token = token
 
-        self.session = OAuth2Session(client=LegacyApplicationClient(client_id=self.client_id))
-
-    def fetch_token(self):
-        self.token = self.session.fetch_token(
-                token_url=self.TOKEN_URL, username=self.username, password=self.password,
-                client_id=self.client_id, client_secret=self.client_secret)
-        return self.token
+        self.session = OAuth2Session(client=Client(client_id=self.client_id,
+                                                   refresh_token=self.offline_token))
 
     def refresh_token(self):
-        self.token = self.session.refresh_token(token_url=self.TOKEN_URL, client_id=self.client_id,
-                                                client_secret=self.client_secret)
+        self.token = self.session.refresh_token(token_url=self.token_url, client_id=self.client_id)
         return self.token
 
 


### PR DESCRIPTION
The legacy authentication method using direct access grants and client credentials obtained from the Customer Portal is deprecated and will be unsupported at the end of the month.

This PR switches to using the standard flow where users obtain an offline/refresh token from the Customer Portal which can be refreshed to obtain an access token.

Direct access grants are disabled, so there is no need for the script to handle user credentials. It simply refreshes the provided offline token as needed.